### PR TITLE
Modify authenticateUser to handle the new callbacks.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "amazon-cognito-identity-js": "^1.19.0",
+    "lodash.clonedeep": "^4.5.0",
     "vuex": "^2.3.1"
   },
   "devDependencies": {

--- a/src/mutation-types.js
+++ b/src/mutation-types.js
@@ -3,3 +3,5 @@ const prefix = 'vue-auth-cognito';
 export const AUTHENTICATE = `${prefix}/AUTHENTICATE`;
 export const ATTRIBUTES = `${prefix}/ATTRIBUTES`;
 export const SIGNOUT = `${prefix}/SIGNOUT`;
+export const COGNITOUSER = `${prefix}/COGNITOUSER`;
+export const REMOVECOGNITOUSER = `${prefix}/REMOVECOGNITOUSER`;

--- a/src/mutations.js
+++ b/src/mutations.js
@@ -10,4 +10,10 @@ export default {
   [types.ATTRIBUTES](state, payload) {
     state.user.attributes = payload;
   },
+  [types.COGNITOUSER](state, payload) {
+    state.cognitoUser = payload;
+  },
+  [types.REMOVECOGNITOUSER](state) {
+    state.cognitoUser = null;
+  },
 };


### PR DESCRIPTION
Add completeNewPasswordChallenge for users created by the admin so users can set their password and be logged in.
Required adding lodash.clonedeep to persist the cognitoUser object